### PR TITLE
Ciao Mauro, così funziona...

### DIFF
--- a/nbproject/project.properties
+++ b/nbproject/project.properties
@@ -35,7 +35,8 @@ jar.compress=false
 javac.classpath=\
     ${libs.hibernate4-persistence.classpath}:\
     ${libs.JAVADB_DRIVER_LABEL.classpath}:\
-    ${file.reference.jandex-2.0.2.Final.jar}
+    ${file.reference.jandex-2.0.2.Final.jar}:\
+    ${libs.hibernate4-persistencemodelgen.classpath}
 # Space-separated list of extra javac options
 javac.compilerargs=
 javac.deprecation=false

--- a/src/META-INF/persistence.xml
+++ b/src/META-INF/persistence.xml
@@ -16,6 +16,8 @@
       <property name="javax.persistence.jdbc.driver" value="org.apache.derby.jdbc.ClientDriver"/>
       <property name="javax.persistence.jdbc.password" value="app"/>
       <property name="hibernate.cache.provider_class" value="org.hibernate.cache.NoCacheProvider"/>
+      <property name="hibernate.connection.autocommit" value="true"/>
+      <property name="hibernate.enable_lazy_load_no_trans" value="true"/>
     </properties>
   </persistence-unit>
 </persistence>


### PR DESCRIPTION
Cercando ulteriormente su Google ho trovato che esiste una proprietà da aggiungere al persistence.xml che rende il comportamento del test di Hibernate identico a quello di EclipseLink: `hibernate.enable_lazy_load_no_trans`, impostata a true.

In ogni caso ne sconsigliano l'uso:
https://vladmihalcea.com/2016/09/05/the-hibernate-enable_lazy_load_no_trans-anti-pattern/

Altre considerazioni:
* Aggiungendo anche la proprietà `hibernate.connection.autocommit` sparisce anche il warning riguardante l'errata chiusura della connessione che si ha alla chiusura dell'`EntityManagerFactory` nel metodo `tearDownClass`
* Per compilare la classe di test ho dovuto aggiungere la seguente dipendenza: `hibernate4-persistencemodelgen`

Ciao,
Sonia